### PR TITLE
Several small code improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * v1.1.1 (2021-08-07)
     * New version published in Mersenne forum in this [post](https://www.mersenneforum.org/showpost.php?p=585093&postcount=1304).
-        * FixeD: URL to download the OE_3000000_C80.txt.
+        * Fixed: URL to download the OE_3000000_C80.txt.
         * Fixed: If an C80 was not found for an exponent, the application was stopped.
         * Remove outputs. It was too verbose when checking multiple exponents.
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+CXX = g++
+FLAGS = -O2
+
+PROG = alimerge
+
+.PHONY: all
+
+all: $(PROG)
+
+$(PROG): $(PROG).o
+	$(CXX) -o $@ $^
+
+%.o: %.cpp
+	$(CXX) $(FLAGS) -c -o $@ $<
+
+clean:
+	rm -f $(PROG) *.o

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 CXX = g++
 FLAGS = -O2
+DEBUG = no
+
+ifeq ($(strip $(DEBUG)),yes)
+    FLAGS += -DDEBUG
+endif
 
 PROG = alimerge
 

--- a/alimerge.cpp
+++ b/alimerge.cpp
@@ -48,14 +48,15 @@ int main(int argc, char** argv) {
 
     std::ifstream ali1, ali2;
     std::string ali1LastC80Composite, commandStr;
-    int base, first, last, exp;
+    std::string base;
+    int first, last, exp;
 
     std::map<std::string, std::string> C80Map;
     std::map<std::string, std::string> ali1Map;
 
     if (argc < 4) {
-        std::cout << "Please invoke as: <./program> <base> <starting exponent> <ending exponent>" << std::endl;
-        return 0;
+        std::cerr << "Please invoke as: <./program> <base> <starting exponent> <ending exponent>" << std::endl;
+        return 1;
     }
 
     std::chrono::system_clock::duration downloadFileDuration = std::chrono::system_clock::duration::zero();
@@ -65,12 +66,12 @@ int main(int argc, char** argv) {
     std::chrono::system_clock::time_point startTimer;
     std::chrono::system_clock::time_point endTimer;
 
+    base = argv[1];
+
 #ifdef _WIN32
-    sscanf_s(argv[1], "%d", &base);
     sscanf_s(argv[2], "%d", &first);
     sscanf_s(argv[3], "%d", &last);
 #else
-    sscanf(argv[1], "%d", &base);
     sscanf(argv[2], "%d", &first);
     sscanf(argv[3], "%d", &last);
 #endif
@@ -94,8 +95,8 @@ int main(int argc, char** argv) {
             C80File.open("OE_3000000_C80.txt");
 
             if (!C80File.is_open()) {
-                std::cout << "Trouble has occurred while trying to read the 80 digit file!" << std::endl;
-                return 0;
+                std::cerr << "Trouble has occurred while trying to read the 80 digit file!" << std::endl;
+                return 1;
             }
         }
         else {
@@ -123,12 +124,16 @@ int main(int argc, char** argv) {
     for (exp = first; exp <= last; exp++) {
 
         startTimer = std::chrono::system_clock::now();
-        //std::cout << "Downloading base " << base << "^" << exp;
+#ifdef DEBUG
+        std::cout << "Downloading base " << base << "^" << exp;
+#endif
 
-        commandStr = R"(curl -q -s -o aliseq1 "http://www.factordb.com/elf.php?seq=)" + std::to_string(base) + "^" + std::to_string(exp) + R"(&type=1")";
+        commandStr = R"(curl -q -s -o aliseq1 "http://www.factordb.com/elf.php?seq=)" + base + "^" + std::to_string(exp) + R"(&type=1")";
         system(commandStr.c_str());
 
-        //std::cout << " : Done" << std::endl;
+#ifdef DEBUG
+        std::cout << " : Done" << std::endl;
+#endif
         endTimer = std::chrono::system_clock::now();
         downloadFileDuration += endTimer - startTimer;
 
@@ -153,8 +158,8 @@ int main(int argc, char** argv) {
             ali1.close();
         }
         else {
-            std::cout << "aliseq1 was not read properly!" << std::endl;
-            return 0;
+            std::cerr << "aliseq1 was not read properly!" << std::endl;
+            return 1;
         }
 
         if (!foundC80) {
@@ -165,15 +170,21 @@ int main(int argc, char** argv) {
         {
             // Throw if not found
             std::string matchingBase = C80Map.at(ali1LastC80Composite);
-            //std::cout << "80 digit composite has a matching in base " << matchingBase << std::endl;
+#ifdef DEBUG
+            std::cout << "80 digit composite has a matching in base " << matchingBase << std::endl;
+#endif
 
             startTimer = std::chrono::system_clock::now();
-            //std::cout << "Downloading base " << matchingBase;
+#ifdef DEBUG
+            std::cout << "Downloading base " << matchingBase;
+#endif
 
             commandStr = R"(curl -q -s -o aliseq2 "http://www.factordb.com/elf.php?seq=)" + matchingBase + R"(&type=1")";
             system(commandStr.c_str());
 
-            //std::cout << " : Done" << std::endl;
+#ifdef DEBUG
+            std::cout << " : Done" << std::endl;
+#endif
             endTimer = std::chrono::system_clock::now();
             downloadFileDuration += endTimer - startTimer;
 
@@ -189,20 +200,22 @@ int main(int argc, char** argv) {
                     auto ali1Search = ali1Map.find(composite);
                     if (ali1Search != ali1Map.end())
                     {
-                        std::cout << std::to_string(base) + "^" + std::to_string(exp) + ":i" + ali1Search->second + " merges with " + matchingBase + ":i" + index << std::endl;
+                        std::cout << base + "^" + std::to_string(exp) + ":i" + ali1Search->second + " merges with " + matchingBase + ":i" + index << std::endl;
                         break;
                     }
                 }
                 ali2.close();
             }
             else {
-                std::cout << "aliseq2 was not read properly!" << std::endl;
-                return 0;
+                std::cerr << "aliseq2 was not read properly!" << std::endl;
+                return 1;
             }
         }
         catch (const std::exception&)
         {
-            //std::cout << "Could not find 80 digit composite " << ali1LastC80Composite << " in OE_3000000_C80.txt" << std::endl;
+#ifdef DEBUG
+            std::cout << "Could not find 80 digit composite " << ali1LastC80Composite << " in OE_3000000_C80.txt" << std::endl;
+#endif
         }
     }
 


### PR DESCRIPTION
This PR includes a few small code improvements.

- Uncomment commented-out debug lines and make their use dependent on a compile-time `DEBUG` flag (set in the Makefile).
- On error, send error messages to `stderr` and exit with `1` exit code.
- Make `base` a string (it is never used as a number, and overflows are an issue).

Incorporates https://github.com/Aillas-5/AliMerge/pull/3.