### PR TITLE
Replace C80 file with new version without fixed upper limit

### DIFF
--- a/alimerge.cpp
+++ b/alimerge.cpp
@@ -76,7 +76,7 @@ int main(int argc, char** argv) {
     sscanf(argv[3], "%d", &last);
 #endif
 
-    std::ifstream C80File("OE_5000000_C80.txt");
+    std::ifstream C80File("OE_C80.txt");
 
     if (C80File.fail())
     {
@@ -88,11 +88,11 @@ int main(int argc, char** argv) {
 
         if (getfile == "y") {
             startTimer = std::chrono::system_clock::now();
-            system(R"(curl -q -s -o OE_5000000_C80.txt "http://www.aliquotes.com/OE_5000000_C80.txt")");
+            system(R"(curl -q -s -o OE_C80.txt "http://www.aliquotes.com/OE_C80.txt")");
             endTimer = std::chrono::system_clock::now();
             downloadFileDuration += endTimer - startTimer;
 
-            C80File.open("OE_5000000_C80.txt");
+            C80File.open("OE_C80.txt");
 
             if (!C80File.is_open()) {
                 std::cerr << "Trouble has occurred while trying to read the 80 digit file!" << std::endl;

--- a/alimerge.cpp
+++ b/alimerge.cpp
@@ -1,15 +1,15 @@
 // This program is designed to look for merges of Aliquot
-// sequences.  It uses the file OE_3000000_C80.txt to
-// match the last occurrence of an 80 digit composite and
-// determines the merged sequence, if any.  If a merge is
-// found, the program determines the merge points between
-// the two sequences.  This program is specifically built
-// to work with base tables found at:
+// sequences.  It uses the file OE_C80.txt to match the
+// last occurrence of an 80 digit composite and determines
+// the merged sequence, if any.  If a merge is found, the
+// program determines the merge points between the two
+// sequences.  This program is specifically built to work
+// with base tables found at:
 //    "Aliquot sequences starting on integer powers n^i"
 // (http://www.aliquotes.com/aliquotes_puissances_entieres.html)
 //
 // It can be compiled in linux via:
-//           g++ <sourcename> -o <finalname>
+//           make
 /////////////////////////////////////////////////////////////////
 
 #include <algorithm>

--- a/alimerge.cpp
+++ b/alimerge.cpp
@@ -128,7 +128,7 @@ int main(int argc, char** argv) {
         std::cout << "Downloading base " << base << "^" << exp;
 #endif
 
-        commandStr = R"(curl -q -s -o aliseq1 "http://www.factordb.com/elf.php?seq=)" + base + "^" + std::to_string(exp) + R"(&type=1")";
+        commandStr = R"(curl -q -s -o aliseq1 "https://factordb.com/elf.php?seq=)" + base + "^" + std::to_string(exp) + R"(&type=1")";
         system(commandStr.c_str());
 
 #ifdef DEBUG
@@ -179,7 +179,7 @@ int main(int argc, char** argv) {
             std::cout << "Downloading base " << matchingBase;
 #endif
 
-            commandStr = R"(curl -q -s -o aliseq2 "http://www.factordb.com/elf.php?seq=)" + matchingBase + R"(&type=1")";
+            commandStr = R"(curl -q -s -o aliseq2 "https://factordb.com/elf.php?seq=)" + matchingBase + R"(&type=1")";
             system(commandStr.c_str());
 
 #ifdef DEBUG
@@ -214,7 +214,7 @@ int main(int argc, char** argv) {
         catch (const std::exception&)
         {
 #ifdef DEBUG
-            std::cout << "Could not find 80 digit composite " << ali1LastC80Composite << " in OE_3000000_C80.txt" << std::endl;
+            std::cout << "Could not find 80 digit composite " << ali1LastC80Composite << " in OE_C80.txt" << std::endl;
 #endif
         }
     }


### PR DESCRIPTION
This replaces #6 by updating the code to use the new `OE_C80.txt` file, which has no fixed upper limit and should need no further filename updates.