### PR TITLE
Validate program arguments

### DIFF
--- a/alimerge.cpp
+++ b/alimerge.cpp
@@ -69,17 +69,30 @@ static unsigned int parseUnsignedInt(const char *str) {
 
 int main(int argc, char** argv) {
 
-    std::ifstream ali1, ali2;
-    std::string ali1LastC80Composite, commandStr;
-    std::string base;
-
-    std::map<std::string, std::string> C80Map;
-    std::map<std::string, std::string> ali1Map;
+    // Validate arguments
 
     if (argc < 3) {
         std::cerr << "Please invoke as: <./program> <base> <starting exponent> [<ending exponent>]" << std::endl;
         return 1;
     }
+
+    std::string base = argv[1];
+
+    unsigned int first = parseUnsignedInt(argv[2]);
+    unsigned int last = (argc > 3) ? parseUnsignedInt(argv[3]) : first;
+
+    if (first > last)
+        std::swap(first, last);
+
+    // Local variables
+
+    std::ifstream ali1, ali2;
+    std::string ali1LastC80Composite, commandStr;
+
+    std::map<std::string, std::string> C80Map;
+    std::map<std::string, std::string> ali1Map;
+
+    // Timers
 
     std::chrono::system_clock::duration downloadFileDuration = std::chrono::system_clock::duration::zero();
     std::chrono::system_clock::duration computationDuration = std::chrono::system_clock::duration::zero();
@@ -88,13 +101,7 @@ int main(int argc, char** argv) {
     std::chrono::system_clock::time_point startTimer;
     std::chrono::system_clock::time_point endTimer;
 
-    base = argv[1];
-
-    unsigned int first = parseUnsignedInt(argv[2]);
-    unsigned int last = (argc > 3) ? parseUnsignedInt(argv[3]) : first;
-
-    if (first > last)
-        std::swap(first, last);
+    // Read C80 file
 
     std::ifstream C80File("OE_C80.txt");
 

--- a/alimerge.cpp
+++ b/alimerge.cpp
@@ -25,7 +25,7 @@
 #include <cstdio>
 #include <cstdlib>
 
-std::string format_duration(std::chrono::milliseconds ms) {
+static std::string formatDuration(std::chrono::milliseconds ms) {
     auto secs = std::chrono::duration_cast<std::chrono::seconds>(ms);
     ms -= std::chrono::duration_cast<std::chrono::milliseconds>(secs);
     auto mins = std::chrono::duration_cast<std::chrono::minutes>(secs);
@@ -264,9 +264,9 @@ int main(int argc, char** argv) {
 
     std::cout << std::endl;
 
-    std::cout << "Total running time   : " << format_duration(totalMs) << " (" << totalSec.count() << " seconds.)" << std::endl;
-    std::cout << "Downloading file time: " << format_duration(downloadMs) << std::endl;
-    std::cout << "Computation only time: " << format_duration(computeMs) << std::endl;
+    std::cout << "Total running time   : " << formatDuration(totalMs) << " (" << totalSec.count() << " seconds.)" << std::endl;
+    std::cout << "Downloading file time: " << formatDuration(downloadMs) << std::endl;
+    std::cout << "Computation only time: " << formatDuration(computeMs) << std::endl;
 
     return 0;
 }

--- a/alimerge.cpp
+++ b/alimerge.cpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 #include <cstdio>
+#include <cstdlib>
 
 std::string format_duration(std::chrono::milliseconds ms) {
     auto secs = std::chrono::duration_cast<std::chrono::seconds>(ms);
@@ -44,12 +45,33 @@ std::string format_duration(std::chrono::milliseconds ms) {
     return ss.str();
 }
 
+static unsigned int parseUnsignedInt(const char *str) {
+    int value;
+
+#ifdef _WIN32
+    const int result = sscanf_s(str, "%d", &value);
+#else
+    const int result = sscanf(str, "%d", &value);
+#endif
+
+    if (result != 1) {
+        std::cerr << "Could not parse integer." << std::endl;
+        std::exit(1);
+    }
+
+    if (value < 0) {
+        std::cerr << "Value cannot be negative." << std::endl;
+        std::exit(1);
+    }
+
+    return static_cast<unsigned int>(value);
+}
+
 int main(int argc, char** argv) {
 
     std::ifstream ali1, ali2;
     std::string ali1LastC80Composite, commandStr;
     std::string base;
-    int first, last, exp;
 
     std::map<std::string, std::string> C80Map;
     std::map<std::string, std::string> ali1Map;
@@ -68,13 +90,8 @@ int main(int argc, char** argv) {
 
     base = argv[1];
 
-#ifdef _WIN32
-    sscanf_s(argv[2], "%d", &first);
-    sscanf_s(argv[3], "%d", &last);
-#else
-    sscanf(argv[2], "%d", &first);
-    sscanf(argv[3], "%d", &last);
-#endif
+    unsigned int first = parseUnsignedInt(argv[2]);
+    unsigned int last = parseUnsignedInt(argv[3]);
 
     std::ifstream C80File("OE_C80.txt");
 
@@ -121,7 +138,7 @@ int main(int argc, char** argv) {
 
     std::cout << "Running base " << base << " from " << first << " through " << last << " . . ." << std::endl;
 
-    for (exp = first; exp <= last; exp++) {
+    for (unsigned int exp = first; exp <= last; exp++) {
 
         startTimer = std::chrono::system_clock::now();
 #ifdef DEBUG

--- a/alimerge.cpp
+++ b/alimerge.cpp
@@ -15,14 +15,11 @@
 #include <algorithm>
 #include <chrono>
 #include <fstream>
-#include <iomanip>
 #include <iostream>
 #include <map>
 #include <sstream>
 #include <string>
-#include <vector>
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 
 static std::string formatDuration(std::chrono::milliseconds ms) {

--- a/alimerge.cpp
+++ b/alimerge.cpp
@@ -57,14 +57,14 @@ static unsigned int parseUnsignedInt(const std::string &str) {
         const unsigned long value = std::stoul(str);
 
         if (value > UINT32_MAX) {
-            std::cerr << "Integer exceeds size limit." << std::endl;
+            std::cerr << "Integer exceeds size limit!" << std::endl;
             std::exit(1);
         }
 
         return static_cast<unsigned int>(value);
     }
     catch (const std::exception&) {
-        std::cerr << "Could not parse integer." << std::endl;
+        std::cerr << "Could not parse integer!" << std::endl;
         std::exit(1);
     }
 }

--- a/alimerge.cpp
+++ b/alimerge.cpp
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 
@@ -45,30 +46,30 @@ std::string format_duration(std::chrono::milliseconds ms) {
     return ss.str();
 }
 
-static void validateUnsignedInt(const std::string str) {
+static void validateUnsignedInt(const std::string &str) {
     if (!std::all_of(str.cbegin(), str.cend(), [](unsigned char c){ return std::isdigit(c); })) {
         std::cerr << "Value must be an unsigned integer!" << std::endl;
         std::exit(1);
     }
 }
 
-static unsigned int parseUnsignedInt(const char *str) {
+static unsigned int parseUnsignedInt(const std::string &str) {
     validateUnsignedInt(str);
 
-    unsigned int value;
+    try {
+        const unsigned long value = std::stoul(str);
 
-#ifdef _WIN32
-    const int result = sscanf_s(str, "%u", &value);
-#else
-    const int result = sscanf(str, "%u", &value);
-#endif
+        if (value > UINT32_MAX) {
+            std::cerr << "Integer exceeds size limit." << std::endl;
+            std::exit(1);
+        }
 
-    if (result != 1) {
+        return static_cast<unsigned int>(value);
+    }
+    catch (const std::exception&) {
         std::cerr << "Could not parse integer." << std::endl;
         std::exit(1);
     }
-
-    return value;
 }
 
 int main(int argc, char** argv) {

--- a/alimerge.cpp
+++ b/alimerge.cpp
@@ -76,7 +76,7 @@ int main(int argc, char** argv) {
     // Validate arguments
 
     if (argc < 3) {
-        std::cerr << "Please invoke as: <./program> <base> <starting exponent> [<ending exponent>]" << std::endl;
+        std::cerr << "Please invoke as: " << argv[0] << " <base> <starting exponent> [<ending exponent>]" << std::endl;
         return 1;
     }
 

--- a/alimerge.cpp
+++ b/alimerge.cpp
@@ -76,8 +76,8 @@ int main(int argc, char** argv) {
     std::map<std::string, std::string> C80Map;
     std::map<std::string, std::string> ali1Map;
 
-    if (argc < 4) {
-        std::cerr << "Please invoke as: <./program> <base> <starting exponent> <ending exponent>" << std::endl;
+    if (argc < 3) {
+        std::cerr << "Please invoke as: <./program> <base> <starting exponent> [<ending exponent>]" << std::endl;
         return 1;
     }
 
@@ -91,7 +91,7 @@ int main(int argc, char** argv) {
     base = argv[1];
 
     unsigned int first = parseUnsignedInt(argv[2]);
-    unsigned int last = parseUnsignedInt(argv[3]);
+    unsigned int last = (argc > 3) ? parseUnsignedInt(argv[3]) : first;
 
     std::ifstream C80File("OE_C80.txt");
 

--- a/alimerge.cpp
+++ b/alimerge.cpp
@@ -45,13 +45,22 @@ std::string format_duration(std::chrono::milliseconds ms) {
     return ss.str();
 }
 
+static void validateUnsignedInt(const std::string str) {
+    if (!std::all_of(str.cbegin(), str.cend(), [](unsigned char c){ return std::isdigit(c); })) {
+        std::cerr << "Value must be an unsigned integer!" << std::endl;
+        std::exit(1);
+    }
+}
+
 static unsigned int parseUnsignedInt(const char *str) {
-    int value;
+    validateUnsignedInt(str);
+
+    unsigned int value;
 
 #ifdef _WIN32
-    const int result = sscanf_s(str, "%d", &value);
+    const int result = sscanf_s(str, "%u", &value);
 #else
-    const int result = sscanf(str, "%d", &value);
+    const int result = sscanf(str, "%u", &value);
 #endif
 
     if (result != 1) {
@@ -59,12 +68,7 @@ static unsigned int parseUnsignedInt(const char *str) {
         std::exit(1);
     }
 
-    if (value < 0) {
-        std::cerr << "Value cannot be negative." << std::endl;
-        std::exit(1);
-    }
-
-    return static_cast<unsigned int>(value);
+    return value;
 }
 
 int main(int argc, char** argv) {
@@ -76,7 +80,9 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    std::string base = argv[1];
+    const std::string base = argv[1];
+
+    validateUnsignedInt(base);
 
     unsigned int first = parseUnsignedInt(argv[2]);
     unsigned int last = (argc > 3) ? parseUnsignedInt(argv[3]) : first;

--- a/alimerge.cpp
+++ b/alimerge.cpp
@@ -93,6 +93,9 @@ int main(int argc, char** argv) {
     unsigned int first = parseUnsignedInt(argv[2]);
     unsigned int last = (argc > 3) ? parseUnsignedInt(argv[3]) : first;
 
+    if (first > last)
+        std::swap(first, last);
+
     std::ifstream C80File("OE_C80.txt");
 
     if (C80File.fail())


### PR DESCRIPTION
I decided to take a more incremental approach compared to the behemoth that is #9. This code (which isn't actually found in #9, at least in this form) properly validates the command-line arguments. There was already existing validation for the argument **count**, but it never checked (other than in the `sscanf` call) whether the values were integers (specifically **unsigned** integers). This code checks all three arguments (even the base, which isn't converted to an `int`, as it is correctly allowed to be arbitrary precision) to ensure they only contain digits. I ported the actual integer conversion to `stoul`, which is more robust than `sscanf` and does not need separate code paths for Unix and Windows.

I also made the third argument optional, making it default to the value of the second argument. This is useful when checking a single sequence. The order of the "minimum" and "maximum" arguments is also validated, being inverted if necessary. (For example, `./alimerge 29 6 4` now searches 29^4 through 29^6, instead of being a no-op.

Please merge this (and the upcoming PRs based on this branch) instead of #9.